### PR TITLE
Improve parsing of tracing context

### DIFF
--- a/rust/tracing/src/util.rs
+++ b/rust/tracing/src/util.rs
@@ -9,36 +9,16 @@ const TRACE_ID_HEADER_KEY: &str = "chroma-traceid";
 const SPAN_ID_HEADER_KEY: &str = "chroma-spanid";
 
 pub fn try_parse_tracecontext(metadata: &MetadataMap) -> (Option<TraceId>, Option<SpanId>) {
-    let mut traceid: Option<TraceId> = None;
-    let mut spanid: Option<SpanId> = None;
-    if metadata.contains_key(TRACE_ID_HEADER_KEY) {
-        let id_res = metadata.get(TRACE_ID_HEADER_KEY).unwrap().to_str();
-        // Failure is not fatal.
-        match id_res {
-            Ok(id) => {
-                let trace_id = TraceId::from_hex(id);
-                match trace_id {
-                    Ok(id) => traceid = Some(id),
-                    Err(_) => traceid = None,
-                }
-            }
-            Err(_) => traceid = None,
-        }
-    }
-    if metadata.contains_key(SPAN_ID_HEADER_KEY) {
-        let id_res = metadata.get(SPAN_ID_HEADER_KEY).unwrap().to_str();
-        // Failure is not fatal.
-        match id_res {
-            Ok(id) => {
-                let span_id = SpanId::from_hex(id);
-                match span_id {
-                    Ok(id) => spanid = Some(id),
-                    Err(_) => spanid = None,
-                }
-            }
-            Err(_) => spanid = None,
-        }
-    }
+    let traceid = metadata
+        .get(TRACE_ID_HEADER_KEY)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|id| TraceId::from_hex(id).ok());
+
+    let spanid = metadata
+        .get(SPAN_ID_HEADER_KEY)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|id| SpanId::from_hex(id).ok());
+
     (traceid, spanid)
 }
 
@@ -48,10 +28,10 @@ pub fn wrap_span_with_parent_context(
 ) -> tracing::Span {
     let (traceid, spanid) = try_parse_tracecontext(metadata);
     // Attach context passed by FE as parent.
-    if traceid.is_some() && spanid.is_some() {
+    if let (Some(traceid), Some(spanid)) = (traceid, spanid) {
         let span_context = SpanContext::new(
-            traceid.unwrap(),
-            spanid.unwrap(),
+            traceid,
+            spanid,
             TraceFlags::new(1),
             true,
             TraceState::default(),


### PR DESCRIPTION
## Summary
- simplify parsing logic for trace and span IDs
- avoid redundant lookups and unwraps when attaching parent context

## Testing
- `cargo check -p chroma-tracing`
- `cargo test -p chroma-tracing --lib`


------
https://chatgpt.com/codex/tasks/task_e_687280f4a1ac8327911d2db55133ecbe